### PR TITLE
Fix TLS behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /.coverage
 /release
 /.cover.out
+/test-configs

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,13 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.37.0
-	github.com/samber/lo v1.27.0
+	github.com/samber/lo v1.28.0
 	github.com/shaj13/go-guardian/v2 v2.11.5
+	github.com/wrouesnel/go.connect-proxy-scheme v0.0.0-20220908065725-e095b839824f
 	github.com/wrouesnel/multihttp v1.0.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.21.0
-	golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48
+	golang.org/x/net v0.0.0-20220907135653-1e95f45603a7
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v3 v3.0.1
 	shanhu.io/virgo v0.0.0-20220803070549-c34ec4ce58b7

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-http-dialer v0.0.0-20161116154839-378f744fb2b8 h1:BhQQWYKJwXPtAhm12d4gQU4LKS9Yov22yOrDc2QA7ho=
+github.com/mwitkow/go-http-dialer v0.0.0-20161116154839-378f744fb2b8/go.mod h1:ntWhh7pzdiiRKBMxUB5iG+Q2gmZBxGxpX1KyK6N8kX8=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nwaples/rardecode v1.1.3 h1:cWCaZwfM5H7nAD6PyEdcVnczzV8i/JtotnyW/dD9lEc=
 github.com/nwaples/rardecode v1.1.3/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
@@ -282,6 +284,8 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/samber/lo v1.27.0 h1:GOyDWxsblvqYobqsmUuMddPa2/mMzkKyojlXol4+LaQ=
 github.com/samber/lo v1.27.0/go.mod h1:it33p9UtPMS7z72fP4gw/EIfQB2eI8ke7GR2wc6+Rhg=
+github.com/samber/lo v1.28.0 h1:rsMtAXNgLuF0Gv3L0ypvm5RsN/vRO0m5pak9uiRb6NU=
+github.com/samber/lo v1.28.0/go.mod h1:it33p9UtPMS7z72fP4gw/EIfQB2eI8ke7GR2wc6+Rhg=
 github.com/shaj13/go-guardian/v2 v2.11.5 h1:qMIKTNhA+3dr5dkohPO+QJkJa+fbNLOU6IuoatTZ2go=
 github.com/shaj13/go-guardian/v2 v2.11.5/go.mod h1:5SQeQxPNr/gJpYg3MFi3tmmHzniLqRyMddwUEZjZcOE=
 github.com/shaj13/libcache v1.0.0/go.mod h1:YCq92Zosqj4erhlLdm2Mu1cX2FDAxjfFOxTphzN7S9U=
@@ -313,6 +317,8 @@ github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/wrouesnel/go.connect-proxy-scheme v0.0.0-20220908065725-e095b839824f h1:oeRobOlsSIN0GI1P1LbNcoIF56+PiEESVZWO8enyyZ0=
+github.com/wrouesnel/go.connect-proxy-scheme v0.0.0-20220908065725-e095b839824f/go.mod h1:+XXgUwf+0HW1d+QPThbs/MsIaeCCUNcCe0fe+fARw1c=
 github.com/wrouesnel/multihttp v1.0.0 h1:SqtRVDxfQUKaYqXA5luMZqRDPTojrKX9BxjS4KkCk1o=
 github.com/wrouesnel/multihttp v1.0.0/go.mod h1:MaW5Vswz2acpsBdcKEz3x9qnFoBuAfjbERgOR0W1nI4=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
@@ -411,6 +417,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48 h1:N9Vc/rorQUDes6B9CNdIxAn5jODGj2wzfrei2x4wNj4=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220907135653-1e95f45603a7 h1:1WGATo9HAhkWMbfyuVU0tEFP88OIkUvwaHFveQPvzCQ=
+golang.org/x/net v0.0.0-20220907135653-1e95f45603a7/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20170912212905-13449ad91cb2/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,11 +88,13 @@ type ServiceSettings struct {
 
 // BasicServiceSettings are the common settings all services share.
 type BasicServiceSettings struct {
-	Timeout    model.Duration     `mapstructure:"timeout,omitempty"`     // Number of seconds to wait for response
-	TLSEnable  bool               `mapstructure:"tls_enable,omitempty"`  // The service uses TLS
-	TLSCACerts TLSCertificatePool `mapstructure:"tls_cacerts,omitempty"` // Path to CAfile to verify the service TLS with
-	Proxy      string             `mapstructure:"proxy,omitempty"`       // Proxy configuration for the service
-	ProxyAuth  *BasicAuthConfig   `mapstructure:"proxy_auth,omitempty"`  // Authentication for the proxy service
+	Timeout           model.Duration     `mapstructure:"timeout,omitempty"`             // Number of seconds to wait for response
+	TLSEnable         bool               `mapstructure:"tls_enable,omitempty"`          // The service uses TLS
+	TLSVerifyFailOk   bool               `mapstructure:"tls_verify_fail_ok,omitempty"`  // The service uses TLS
+	TLSCertificatePin *TLSCertificateMap `mapstructure:"tls_certificate_pin,omitempty"` // Map of certificates which *must* be returned by the service. If null, ignored.
+	TLSCACerts        TLSCertificatePool `mapstructure:"tls_cacerts,omitempty"`         // Path to CAfile to verify the service TLS with
+	Proxy             string             `mapstructure:"proxy,omitempty"`               // Proxy configuration for the service
+	ProxyAuth         *BasicAuthConfig   `mapstructure:"proxy_auth,omitempty"`          // Authentication for the proxy service
 }
 
 type ChallengeResponseServiceSettings struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,13 +88,14 @@ type ServiceSettings struct {
 
 // BasicServiceSettings are the common settings all services share.
 type BasicServiceSettings struct {
-	Timeout           model.Duration     `mapstructure:"timeout,omitempty"`             // Number of seconds to wait for response
-	TLSEnable         bool               `mapstructure:"tls_enable,omitempty"`          // The service uses TLS
-	TLSVerifyFailOk   bool               `mapstructure:"tls_verify_fail_ok,omitempty"`  // The service uses TLS
-	TLSCertificatePin *TLSCertificateMap `mapstructure:"tls_certificate_pin,omitempty"` // Map of certificates which *must* be returned by the service. If null, ignored.
-	TLSCACerts        TLSCertificatePool `mapstructure:"tls_cacerts,omitempty"`         // Path to CAfile to verify the service TLS with
-	Proxy             string             `mapstructure:"proxy,omitempty"`               // Proxy configuration for the service
-	ProxyAuth         *BasicAuthConfig   `mapstructure:"proxy_auth,omitempty"`          // Authentication for the proxy service
+	Timeout                 model.Duration     `mapstructure:"timeout,omitempty"`             // Number of seconds to wait for response
+	TLSEnable               bool               `mapstructure:"tls_enable,omitempty"`          // The service uses TLS
+	TLSVerifyFailOk         bool               `mapstructure:"tls_verify_fail_ok,omitempty"`  // The service uses TLS
+	TLSServerNameIndication *string            `mapstructure:"tls_sni_name,omitempty"`        // The TLS SNI name to send.
+	TLSCertificatePin       *TLSCertificateMap `mapstructure:"tls_certificate_pin,omitempty"` // Map of certificates which *must* be returned by the service. If null, ignored.
+	TLSCACerts              TLSCertificatePool `mapstructure:"tls_cacerts,omitempty"`         // Path to CAfile to verify the service TLS with
+	Proxy                   string             `mapstructure:"proxy,omitempty"`               // Proxy configuration for the service
+	ProxyAuth               *BasicAuthConfig   `mapstructure:"proxy_auth,omitempty"`          // Authentication for the proxy service
 }
 
 type ChallengeResponseServiceSettings struct {

--- a/pkg/config/models.go
+++ b/pkg/config/models.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
@@ -13,6 +14,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/wrouesnel/poller_exporter/pkg/certutils"
 
 	"github.com/samber/lo"
 
@@ -220,6 +223,131 @@ func (u *URL) MarshalText() ([]byte, error) {
 		return []byte(u.String()), nil
 	}
 	return []byte(""), nil
+}
+
+// TLSCertificateMap encodes a list of certificates and stores them in a hashmap
+// for easy lookups. It is similar to the standard library CertPool.
+type Sum224 [sha256.Size224]byte
+type TLSCertificateMap struct {
+	certMap  map[Sum224]*x509.Certificate
+	original []string
+}
+
+func (t *TLSCertificateMap) GetCerts() []*x509.Certificate {
+	if t.certMap == nil {
+		return []*x509.Certificate{}
+	}
+
+	return lo.MapToSlice(t.certMap, func(_ Sum224, v *x509.Certificate) *x509.Certificate {
+		return v
+	})
+}
+
+func (t *TLSCertificateMap) HasCert(cert *x509.Certificate) bool {
+	if t.certMap == nil {
+		return false
+	}
+	_, found := t.certMap[sha256.Sum224(cert.Raw)]
+	return found
+}
+
+func (t *TLSCertificateMap) HashCert(cert *x509.Certificate) Sum224 {
+	return sha256.Sum224(cert.Raw)
+}
+
+// AddCert adds a certificate to a pool.
+func (t *TLSCertificateMap) AddCert(cert *x509.Certificate) error {
+	if t.certMap == nil {
+		t.certMap = make(map[Sum224]*x509.Certificate)
+	}
+
+	// Just allow this. It's not fatal.
+	if cert == nil {
+		return nil
+	}
+
+	// Hash the certificate
+	rawSum224 := sha256.Sum224(cert.Raw)
+
+	// Check that the certificate isn't being added twice.
+	if _, found := t.certMap[rawSum224]; found {
+		return nil
+	}
+
+	t.certMap[rawSum224] = cert
+	return nil
+}
+
+// MapStructureDecode implements unmarshalling for TLSCertificateMap
+//nolint: funlen,cyclop
+func (t *TLSCertificateMap) MapStructureDecode(input interface{}) error {
+	// Get the slice
+	interfaceSlice, ok := input.([]interface{})
+	if !ok {
+		return errors.Wrapf(ErrInvalidInputType, "expected []string got %T", input)
+	}
+
+	// Get the strings
+	strErrors := lo.Map(interfaceSlice, func(t interface{}, i int) lo.Tuple2[string, bool] {
+		strValue, ok := t.(string)
+		return lo.T2(strValue, ok)
+	})
+
+	// Extract errors
+	err := lo.Reduce[lo.Tuple2[string, bool], error](strErrors, func(r error, t lo.Tuple2[string, bool], _ int) error {
+		// Return the first error we got if its there
+		if r != nil {
+			return r
+		}
+		_, ok := lo.Unpack2(t)
+		if !ok {
+			return errors.Wrapf(ErrInvalidInputType, "invalid input type in certificate list")
+		}
+		return nil
+	}, nil)
+	if err != nil {
+		return errors.Wrapf(err, "TLSCertificatePool.MapStructureDecode")
+	}
+
+	// Flatten the valid list out to []string
+	caCertSpecEntries := lo.Map(strErrors, func(t lo.Tuple2[string, bool], _ int) string {
+		value, _ := lo.Unpack2(t)
+		return value
+	})
+
+	for idx, entry := range caCertSpecEntries {
+		var pem []byte
+		itemSample := ""
+		if _, err := os.Stat(entry); err == nil {
+			// Is a file
+			pem, err = ioutil.ReadFile(entry)
+			if err != nil {
+				return errors.Wrapf(err, "could not read certificate file: %s", entry)
+			}
+			itemSample = entry
+		} else {
+			pem = []byte(entry)
+			if len(entry) < TLSCertificatePoolMaxNonFileEntryReturn {
+				itemSample = entry
+			} else {
+				itemSample = entry[:TLSCertificatePoolMaxNonFileEntryReturn]
+			}
+		}
+
+		certificates, err := certutils.LoadCertificatesFromPem(pem)
+		if err != nil {
+			return errors.Wrapf(ErrInvalidPEMFile, "failed at item %v: %v", idx, itemSample)
+		}
+
+		for idx, cert := range certificates {
+			if err := t.AddCert(cert); err != nil {
+				return errors.Wrapf(ErrInvalidPEMFile, "failed at item %v: %v", idx, itemSample)
+			}
+		}
+	}
+
+	t.original = caCertSpecEntries
+	return nil
 }
 
 // TLSCertificatePool is our custom type for decoding a certificate pool out of

--- a/pkg/pollers/http_service.go
+++ b/pkg/pollers/http_service.go
@@ -78,7 +78,7 @@ func NewHTTPService(host *Host, opts config.HTTPServiceConfig) *HTTPService {
 		responseReceived: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace:   Namespace,
 			Subsystem:   "service",
-			Name:        "http_response_rceived_bool",
+			Name:        "http_response_received_bool",
 			Help:        "Was an HTTP response received?",
 			ConstLabels: constantLabels,
 		}),

--- a/pkg/pollers/http_service.go
+++ b/pkg/pollers/http_service.go
@@ -335,7 +335,7 @@ func (hs *HTTPService) Poll() {
 	defer resp.Body.Close()
 	l.Debug("HTTP response",
 		zap.String("hostname", hs.Host().Hostname),
-		zap.Uint64("hostname", hs.Port()),
+		zap.Uint64("port", hs.Port()),
 		zap.Int("http_status_code", resp.StatusCode),
 		zap.String("http_status", resp.Status))
 	// Service responded - set status code

--- a/pkg/pollers/poller.go
+++ b/pkg/pollers/poller.go
@@ -26,7 +26,7 @@ const MetricLabelFailed = "failed"
 const (
 	PollerTypeBasic             = "basic"
 	PollerTypeChallengeResponse = "challenge-response"
-	PollyerTypeHTTP             = "http"
+	PollerTypeHTTP              = "http"
 )
 
 // PollConnection wraps net.Conn and carries additional information about the

--- a/pkg/pollers/poller.go
+++ b/pkg/pollers/poller.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/magisterquis/connectproxy"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"golang.org/x/net/proxy"
@@ -29,13 +28,6 @@ const (
 	PollerTypeChallengeResponse = "challenge-response"
 	PollyerTypeHTTP             = "http"
 )
-
-//nolint:gochecknoinits
-func init() {
-	// Register additional proxy schemes
-	proxy.RegisterDialerType("http", connectproxy.New)
-	proxy.RegisterDialerType("https", connectproxy.New)
-}
 
 // PollConnection wraps net.Conn and carries additional information about the
 // service poll.

--- a/pkg/pollers/tls_service.go
+++ b/pkg/pollers/tls_service.go
@@ -22,10 +22,22 @@ type TLSService struct {
 
 	CertificateMatchesPin prometheus.Gauge // Whether the certificate matches the pinned certificate list
 
-	tlsRootCAs *x509.CertPool            // Certificate pool to validate the service with
-	tlsPinMap  *config.TLSCertificateMap // TLS certificates which are considered pinned
+	tlsVerifyFailOk bool                      // Status can be OK if TLS verify fails.
+	tlsSniName      string                    // SNI name if status is not okay
+	tlsRootCAs      *x509.CertPool            // Certificate pool to validate the service with
+	tlsPinMap       *config.TLSCertificateMap // TLS certificates which are considered pinned
+
+	statusTLS Status // tracks whether the current TLS status is verified
 
 	BasePoller
+}
+
+func (s *TLSService) Status() Status {
+	if s.BasePoller.Status() == PollStatusSuccess {
+		// Port is Open. Check if certificate verified.
+		return s.statusTLS
+	}
+	return s.BasePoller.Status()
 }
 
 func (s *TLSService) Describe(ch chan<- *prometheus.Desc) {
@@ -76,9 +88,13 @@ func (s *TLSService) doPoll() *PollConnection {
 
 // Scrape TLS data from a dialed connection.
 func (s *TLSService) scrapeTLS(conn *PollConnection) *PollConnection {
-	tlsConfig := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	tlsConfig := &tls.Config{
+		ServerName:         s.tlsSniName,
+		InsecureSkipVerify: true, //nolint:gosec
+	}
 	tlsConn := tls.Client(conn, tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {
+		s.statusTLS = PollStatusFailed
 		return nil
 	}
 
@@ -93,24 +109,32 @@ func (s *TLSService) scrapeTLS(conn *PollConnection) *PollConnection {
 		Intermediates: intermediates,
 	}
 
-	if s.tlsPinMap != nil {
-		if s.tlsPinMap.HasCert(hostcert) {
-			s.CertificateMatchesPin.Set(1)
-		} else {
-			s.CertificateMatchesPin.Set(0)
-		}
-	}
-
 	if _, err := hostcert.Verify(opts); err != nil {
 		s.CertificateValid.WithLabelValues(hostcert.Subject.CommonName).Set(0)
 		s.CertificateValidCount.WithLabelValues(MetricLabelFailed).Inc()
+		if s.tlsVerifyFailOk {
+			s.statusTLS = PollStatusSuccess
+		} else {
+			s.statusTLS = PollStatusFailed
+		}
 	} else {
 		s.CertificateValid.WithLabelValues(hostcert.Subject.CommonName).Set(1)
 		s.CertificateValidCount.WithLabelValues(MetricLabelSuccess).Inc()
+		s.statusTLS = PollStatusSuccess
 	}
 
 	s.CertificateNotAfter.WithLabelValues(hostcert.Subject.CommonName).Set(float64(hostcert.NotAfter.Unix()))
 	s.CertificateNotBefore.WithLabelValues(hostcert.Subject.CommonName).Set(float64(hostcert.NotBefore.Unix()))
+
+	if s.tlsPinMap != nil {
+		if s.tlsPinMap.HasCert(hostcert) {
+			s.CertificateMatchesPin.Set(1)
+			s.statusTLS = PollStatusSuccess
+		} else {
+			s.CertificateMatchesPin.Set(0)
+			s.statusTLS = PollStatusFailed
+		}
+	}
 
 	return &PollConnection{
 		Conn:     tlsConn,

--- a/poller_exporter.complete.yml
+++ b/poller_exporter.complete.yml
@@ -150,6 +150,11 @@ hosts:
         timeout: 5s # timeout overrides the global default service timeout
         tls_enable: true # controls whether TLS is started on connection and certificate/expiry/validity metrics collected
         tls_verify_fail_ok: true # accept an invalid certificate as status OK
+        tls_sni_name: myhost # if specified, this TLS SNI name will be sent to the host.
+                        # if omitted and the host is a hostname, then the hostname will be
+                        # sent by default. If blank, then the hostname is not sent as an SNI indication.
+                        # If omitted and an HTTP check with a URL is specified, then the name in the
+                        # HTTP Server URL is used.
         # require an exact match of a certificate to report status OK for this service.
         # generally should be used with tls_verify_fail_ok to track whether the certificate
         # issued by a private CA has changed

--- a/poller_exporter.complete.yml
+++ b/poller_exporter.complete.yml
@@ -78,6 +78,8 @@ host_defaults:
 
     # TLS enable
     tls_enable: false
+    # Enable TLS but do not record status failure for invalid certificate
+    tls_verify_fail_ok: false
     # TLS certificate CAs to use.
     tls_cacerts:
       # system means use the system authorities
@@ -147,6 +149,45 @@ hosts:
         port: 465 # port is the port number to connect to.
         timeout: 5s # timeout overrides the global default service timeout
         tls_enable: true # controls whether TLS is started on connection and certificate/expiry/validity metrics collected
+        tls_verify_fail_ok: true # accept an invalid certificate as status OK
+        # require an exact match of a certificate to report status OK for this service.
+        # generally should be used with tls_verify_fail_ok to track whether the certificate
+        # issued by a private CA has changed
+        tls_certificate_pin:
+        - |
+          -----BEGIN CERTIFICATE-----
+          MIIFbjCCA1agAwIBAgIIFwhpEf1Sq7cwDQYJKoZIhvcNAQELBQAwPDEVMBMGA1UE
+          BhMMVGVzdCBDb3VudHJ5MREwDwYDVQQKEwhUZXN0IE9yZzEQMA4GA1UECxMHVGVz
+          dCBPVTAeFw0yMjA4MDUwOTMzMDZaFw0yMzA4MDUxNTMzMDZaMFAxFTATBgNVBAYT
+          DFRlc3QgQ291bnRyeTERMA8GA1UEChMIVGVzdCBPcmcxEDAOBgNVBAsTB1Rlc3Qg
+          T1UxEjAQBgNVBAMTCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCC
+          AgoCggIBALv3TIu1aXaJdaKWZplTVPiR/Oiz3KujrVb55nCOsqQVQ2eRYMWJmFb7
+          75wt/qW7aXrw89DeoqFVPn4eoReTOfxs36ZQxY7kAJq6NU6QGbKXRr5yhwIOnh8z
+          mUohxHrz/ec8Jt5g74NTHEb6bq7aphQU0rE/e5q++iuQxiY15UaKhIJsEjPhmqyv
+          8tiHKEHQfQ0UTeQBq3N+7qC83QGp8i9NqoO3dX9tx0Bz6h+x2O+SkgACGJy9k3za
+          QbIiPDIqkvGGbxx5WVV4ruoa4TXRP0TbMpULnRp3uYiBD9ORjrzE1RobXBxkkxjA
+          Oo7ZNKib8RR1lLf3LLOgsJ8bJ6B8lVAZrK2zuCnIXUxm0EERtO/UHXHh1PRgrcyq
+          Ilox/oQDSAcuaCc/T4LPLAPzcdJzZd/aYq1tvwSZPc0k3fdK2TwUezInIYagfuAQ
+          QFGliIFGd55eSz8rZcl15wUy8lyN30detPbAL9JKxKoP6+vGFhmiwG5lvw9ml/aZ
+          sY6aXeRDVoJBmvhn6G1O9ZlZB+K3ZSQrCFGG6eLM4hIR8DeKxeCas+c+cs9G0rkg
+          Ww3kIONM9ENJlyfj1VvH/YcSEXRspuWIrJBePGpAjBYKH15jMgT4GbXwuBbwh5ll
+          5qeq/JUr4sTA3u3VtaWtirIV+yiGo6Mf9TZ4446pm9Vdiq5G7nrJAgMBAAGjYDBe
+          MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
+          DAYDVR0TAQH/BAIwADAfBgNVHREEGDAWgglsb2NhbGhvc3SBCXRlc3RAdGVzdDAN
+          BgkqhkiG9w0BAQsFAAOCAgEAOzE0UCCtPqHTgWw7qui8V0FjDAXyi+WF6tet3DBM
+          OhcmqJf4z6BZf0lONGk4GT4sXqDW/hcOWwaVXujDTcxIVybI35bCn/T2Qj3X8qUO
+          Hq3lGWyP9CEJOL9Ubl6qWTmLrDLM0TPv+BqRxpJfWFMrfk+pZnp68b2ywlrXyXaR
+          wfgnT5O4G38bBxT18GIyV+e8vp4OXJBeotLbkBBYb1COoXtLXzcoFAiKyCCur5pQ
+          dKJUFBjEW5xEr2BZ5kJoKyBsRsqViJUCIHW24GXZY+/OzGVPicN2FusiNTFuCX7m
+          F/MaHeUgf+tcZnv9yA4GTEZbCsziAVeUBl+abkuLZpeBJYtBYnSrEtrq25Wkzkut
+          lWYtBJPhhtZAm2p/fxncT7qspBO8F5ntmFaYqZgoKoxrYXWiP8glsJVuJtLUJPao
+          GMNG8psGhJtx4p+kW9J9DolD6LSCmrLfWBQz7h1C1nFfpMljGi+9Amfp3YQDM7ej
+          gHIH2ZYAEivSn5gQC8pymYgpjxg8WkPMCEBUR54mGUIaONgD36o50kCHkqmTxTwf
+          i+AOopayK+iTOx1xcp3eJUp439Na7rXlUbvlfRGZRjlRWXjRIsVwBKyu0YpS9zLl
+          tAq9Uwppt5PDIo/fevLMbu5Upi8/yaTBaycAQV+NMQe9irGxxZc4GpB6//wVEWdG
+          ZNs=
+          -----END CERTIFICATE-----
+        - test_data/localhost.crt
         tls_cacerts: # tls_cacert specifies to try validating the certificate from the given list
         - test_data/tls_cacerts/other.crt
 

--- a/poller_exporter.init
+++ b/poller_exporter.init
@@ -16,7 +16,7 @@
 NAME=poller_exporter
 # Daemon name, where is the actual executable
 DAEMON=/usr/local/bin/poller_exporter
-ARGS="-collector.config /usr/local/etc/poller_exporter.yml"
+ARGS="--config-file /etc/poller_exporter.yml"
 # pid file for the daemon
 PIDFILE=/var/run/poller_exporter.pid
 

--- a/poller_exporter.systemd
+++ b/poller_exporter.systemd
@@ -8,7 +8,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/local/bin/poller_exporter -collector.config /etc/poller_exporter.yml
+ExecStart=/usr/local/bin/poller_exporter --config-file /etc/poller_exporter.yml
 
 Restart=always
 RestartSec=10


### PR DESCRIPTION
* Fix the behavior of TLS SNI name sending with sensible defaults.
* Add status fail if TLS certificate does not verify, with overrides for ignoring the status and pinning an upstream certificate identity
* Fix some spelling mistakes including the `http_response_received_bool` spelling