### PR TITLE
tls_service: Fix obtained roots not set as verify roots

### DIFF
--- a/pkg/pollers/tls_service.go
+++ b/pkg/pollers/tls_service.go
@@ -3,6 +3,7 @@ package pollers
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"math"
 
 	"github.com/wrouesnel/poller_exporter/pkg/config"
 
@@ -107,6 +108,7 @@ func (s *TLSService) scrapeTLS(conn *PollConnection) *PollConnection {
 	opts := x509.VerifyOptions{
 		DNSName:       s.Host().Hostname,
 		Intermediates: intermediates,
+		Roots:         s.tlsRootCAs,
 	}
 
 	if _, err := hostcert.Verify(opts); err != nil {
@@ -134,6 +136,8 @@ func (s *TLSService) scrapeTLS(conn *PollConnection) *PollConnection {
 			s.CertificateMatchesPin.Set(0)
 			s.statusTLS = PollStatusFailed
 		}
+	} else {
+		s.CertificateMatchesPin.Set(math.NaN())
 	}
 
 	return &PollConnection{


### PR DESCRIPTION
The TLS service didn't actually use specified roots, and was defaulting to system roots.

Release v0.11.0 will be yanked and v0.12.0 will be published to reflect this fix.

The CertificateMatchesPin metric is also updated to return NaN if no pin certificates are set.