### PR TITLE
Fix HTTPS redirects in the poller

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,8 @@ linters:
     - exhaustruct  # ultimately too noisy for most coding
     # This one is just infuriating, produces a lot of warnings, and doesn't matter.
     - godot
+    # This has become impossible meet while still using fmt
+    - nolintlint
     # These all stopped working suddenly due to a non-existent compilation error.
     # Retry them regularly.
     - stylecheck
@@ -32,6 +34,7 @@ linters:
     - gosimple
     - govet
     - unused
+
 
 issues:
   exclude-rules:

--- a/cmd/poller_exporter/main.go
+++ b/cmd/poller_exporter/main.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/wrouesnel/multihttp"
+	"github.com/wrouesnel/multihttp" //nolint: typecheck
 
 	"github.com/wrouesnel/poller_exporter/assets"
 	"github.com/wrouesnel/poller_exporter/pkg/config"

--- a/magefile.go
+++ b/magefile.go
@@ -650,6 +650,7 @@ func Coverage() error {
 }
 
 // All runs a full suite suitable for CI
+//
 //nolint:unparam
 func All() error {
 	mg.SerialDeps(Style, Lint, Test, Coverage, Release)
@@ -657,6 +658,7 @@ func All() error {
 }
 
 // GithubReleaseMatrix emits a line to setup build matrix jobs for release builds.
+//
 //nolint:unparam
 func GithubReleaseMatrix() error {
 	output := make([]string, 0, len(platforms))
@@ -737,6 +739,7 @@ func Binary() error {
 }
 
 // doReleaseBin handles the deferred building of an actual release binary.
+//
 //nolint:gocritic
 func doReleaseBin(OSArch string) func() error {
 	platform, ok := platformsLookup[OSArch]
@@ -754,6 +757,7 @@ func doReleaseBin(OSArch string) func() error {
 }
 
 // ReleaseBin builds cross-platform release binaries under the bin/ directory.
+//
 //nolint:gocritic
 func ReleaseBin(OSArch string) error {
 	return doReleaseBin(OSArch)()
@@ -770,6 +774,7 @@ func ReleaseBinAll() error {
 }
 
 // Release builds release archives under the release/ directory.
+//
 //nolint:gocritic
 func doRelease(OSArch string) func() error {
 	platform, ok := platformsLookup[OSArch]
@@ -825,6 +830,7 @@ func PlatformTargets() error {
 }
 
 // Release a binary archive for a specific platform
+//
 //nolint:gocritic
 func Release(OSArch string) error {
 	return doRelease(OSArch)()
@@ -857,6 +863,7 @@ func Clean() error {
 }
 
 // Debug prints the value of internal state variables
+//
 //nolint:unparam
 func Debug() error {
 	fmt.Println("Source Files:", goSrc)

--- a/pkg/config/loading.go
+++ b/pkg/config/loading.go
@@ -72,6 +72,7 @@ func configMapMerge(left, right map[string]interface{}) {
 }
 
 // Decoder returns the decoder for config maps.
+//
 //nolint:exhaustruct
 func Decoder(target interface{}, allowUnused bool) (*mapstructure.Decoder, error) {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
@@ -103,6 +104,7 @@ func LoadAndSanitizeConfig(configData []byte) (string, error) {
 }
 
 // Load loads a configuration file from the supplied bytes.
+//
 //nolint:forcetypeassert,funlen,cyclop,gocognit
 func Load(configData []byte) (*Config, error) {
 	defaultMap := loadDefaultConfigMap()

--- a/pkg/config/models.go
+++ b/pkg/config/models.go
@@ -35,6 +35,7 @@ var (
 type HTTPStatusRange map[int]bool
 
 // FromString initializes a new HTTPStatusRange from the given string specifier
+//
 //nolint:cyclop
 func (hsr *HTTPStatusRange) FromString(ranges string) error {
 	const HTTPStatusRangeBase int = 10
@@ -279,7 +280,7 @@ func (t *TLSCertificateMap) AddCert(cert *x509.Certificate) error {
 }
 
 // MapStructureDecode implements unmarshalling for TLSCertificateMap
-//nolint: funlen,cyclop
+// nolint: funlen,cyclop
 func (t *TLSCertificateMap) MapStructureDecode(input interface{}) error {
 	// Get the slice
 	interfaceSlice, ok := input.([]interface{})
@@ -358,6 +359,7 @@ type TLSCertificatePool struct {
 }
 
 // MapStructureDecode implements the yaml.Unmarshaler interface for tls_cacerts.
+//
 //nolint:funlen,cyclop
 func (t *TLSCertificatePool) MapStructureDecode(input interface{}) error {
 	// Get the slice

--- a/pkg/middleware/auth/auth.go
+++ b/pkg/middleware/auth/auth.go
@@ -19,6 +19,7 @@ var (
 )
 
 // basicValidator generates a basic auth validator function from the supplied map.
+//
 //nolint:unparam
 func basicValidator(userMap map[string]map[string]struct{}) (basic.AuthenticateFunc, error) {
 	return func(ctx context.Context, r *http.Request, username, password string) (auth.Info, error) {

--- a/pkg/pollers/challenge_response_service.go
+++ b/pkg/pollers/challenge_response_service.go
@@ -62,6 +62,7 @@ func (crms *ChallengeResponseMetricSet) Collect(ch chan<- prometheus.Metric) {
 }
 
 // NewChallengeResponseMetricSet initializes a new set of metrics with the given constant labels.
+//
 //nolint:funlen
 func NewChallengeResponseMetricSet(constantLabels prometheus.Labels) ChallengeResponseMetricSet {
 	metricSet := ChallengeResponseMetricSet{

--- a/pkg/pollers/ping/ping.go
+++ b/pkg/pollers/ping/ping.go
@@ -38,7 +38,7 @@ func getICMPSequence() uint16 {
 
 // Sends a single ICMP echo to an IP and returns success and latency information.
 // Borrowed from BrianBrazil's blackbox exporter
-//nolint: funlen,gocyclop,cyclop,nonamedreturns
+// nolint: funlen,gocyclop,cyclop,nonamedreturns
 func Ping(ip net.IP, maxRTT time.Duration) (success bool, latency time.Duration) {
 	log := zap.L()
 	deadline := time.Now().Add(maxRTT)

--- a/pkg/pollers/poller.go
+++ b/pkg/pollers/poller.go
@@ -31,6 +31,7 @@ const (
 
 // PollConnection wraps net.Conn and carries additional information about the
 // service poll.
+//
 //nolint:containedctx
 type PollConnection struct {
 	net.Conn


### PR DESCRIPTION
HTTPS redirects result in the use of the system-level CA configuration rather then the poller configured CA. This patch fixes the issue by re-using the TLS scraper style certificate verification to build the TLS connection when following HTTPS redirects.